### PR TITLE
update to latest package version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
-// swift-tools-version:5.2
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version:5.3
 
 import PackageDescription
 


### PR DESCRIPTION
this removes a warning I was getting when using this in a package that was using version 5.3 
upgrading the package version to 5.3 removes this warning.
I think that this is probably a bug in SPM and this kind of change may not be needed in future.